### PR TITLE
マスの一部の背景色を変更

### DIFF
--- a/animation_sugoroku/src/components/EventModal.jsx
+++ b/animation_sugoroku/src/components/EventModal.jsx
@@ -12,21 +12,31 @@ export const EventModal = (props) => {
 
   const getEventfromEventId = (eventId) => {
     switch (eventId) {
-      case 0: return "";
-      case 1: return "1マス進む";
-      case 2: return "2マス進む";
-      case 3: return "3マス進む";
-      case 4: return "4マス進む";
-      case 5: return "5マス進む";
-      case 6: return "6マス進む";
-      case 7: return "1マス戻る";
-      case 8: return "2マス戻る";
-      case 9: return "3マス戻る";
-      case 10: return "4マス戻る";
-      case 11: return "5マス戻る";
-      case 12: return "6マス戻る";
-      case 13: return "1回休み";
-    }
+      case 0: return ""; 
+      case 1: return "1マス進む"; 
+      case 2: return "2マス進む"; 
+      case 3: return "3マス進む"; 
+      case 4: return "4マス進む"; 
+      case 5: return "5マス進む"; 
+      case 6: return "6マス進む"; 
+      case 7: return "1マス戻る"; 
+      case 8: return "2マス戻る"; 
+      case 9: return "3マス戻る"; 
+      case 10: return "4マス戻る"; 
+      case 11: return "5マス戻る"; 
+      case 12: return "6マス戻る"; 
+      case 13: return "1回休み"; 
+      case 15: return "+100点"
+      case 16: return "+200点"
+      case 17: return "+300点"
+      case 18: return "+400点"
+      case 19: return "+500点"
+      case 20: return "-100点"
+      case 21: return "-200点"
+      case 22: return "-300点"
+      case 23: return "-400点"
+      case 24: return "-500点"
+  }
   }
 
 

--- a/animation_sugoroku/src/components/Masu.jsx
+++ b/animation_sugoroku/src/components/Masu.jsx
@@ -43,6 +43,12 @@ export default class Masu extends React.Component {
     }
 
     render() {
+        let masuColor = 'black';
+        if (this.props.masu.squareEffect > 0) {
+            masuColor = 'cyan';
+        } else if (this.props.masu.squareEffect < 0) {
+            masuColor = 'orangered';
+        }
         return (
             <>
             <MasuStyle>
@@ -57,7 +63,7 @@ export default class Masu extends React.Component {
                             <div style={{ "display":"table-cell", "verticalAlign": "middle", "padding":"0", "margin":"0"}}>{this.props.masu.title}</div>
                         </div>
                     
-                    <Card sx={{ width: "80%", marginLeft: "auto", marginRight: "auto", top: 8, position: "relative", borderRadius: 2, bgcolor: "#FF8888" }}>
+                    <Card sx={{ width: "80%", marginLeft: "auto", marginRight: "auto", top: 8, position: "relative", borderRadius: 2, bgcolor: masuColor }}>
                         {this.getEventfromEventId(this.props.masu.squareEventId)}
                     </Card>
                 </Card>


### PR DESCRIPTION
このブランチでは以下の変更を行った
- 得点の上下効果について、マスカードに表示されない不具合の修正
- アクションを示す部分の背景色を効果のプラスマイナスにより決定するロジックの追加